### PR TITLE
chore: tbls の設定ファイルを追加

### DIFF
--- a/backend/.tbls.yml
+++ b/backend/.tbls.yml
@@ -1,0 +1,11 @@
+# tbls: DBのスキーマからドキュメント（ER図・テーブル定義）を生成する。
+#
+#   tbls doc          # docPath へドキュメントを生成
+#   tbls diff         # 生成済みドキュメントと実DBの差分
+#   tbls coverage     # テーブル・カラムのコメント網羅率
+#
+# ローカルのDockerのPostgresはTLS無効なので sslmode=disable が要る。
+# 認証情報は docker-compose.yml と同じ開発用の固定値。
+dsn: postgres://postgres:postgres@localhost:5432/transcendence?sslmode=disable
+
+docPath: docs/schema


### PR DESCRIPTION
## 概要
`backend/.tbls.yml` を追加。これが無いと tbls は DSN を見つけられず `unsupported driver ''` で失敗する。

## 内容
```yaml
dsn: postgres://postgres:postgres@localhost:5432/transcendence?sslmode=disable
docPath: docs/schema
```

- ローカルの Docker Postgres は `ssl = off` のため `sslmode=disable` が必須（Go の lib/pq は既定が `require`）
- 認証情報は `docker-compose.yml` / `.env.example` と同じ開発用固定値

## 確認
- `tbls coverage`（引数なし）→ 動作する
- `tbls doc` → `docs/schema/{README.md,schema.svg,schema.json}` を生成

## 注意
DB にまだテーブルが無い（マイグレーション未適用）ため、現時点で生成されるドキュメントは空。
生成物は本 PR には含めていない。`docs/schema/` を Git 管理するかは別途決める必要あり。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HWQRxqNZavXrfp9r7VpCA3