### PR TITLE
fix: frontend が backend の起動を待つようにする

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,6 +66,15 @@ services:
     depends_on:
       db:
         condition: service_healthy
+    # air が go build を終えて :4000 を listen するまでは通らない。
+    # frontend はこれが通るまで起動を待つ（起動直後の ECONNREFUSED を防ぐ）。
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:4000/"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+      # migration の適用と初回ビルドで時間がかかる。その間の失敗は回数に数えない。
+      start_period: 90s
     volumes:
       - ./backend:/app
     networks:
@@ -87,7 +96,8 @@ services:
       # frontend 自身を指すので、サービス名で backend を呼ぶ。
       API_URL: http://backend:4000
     depends_on:
-      - backend
+      backend:
+        condition: service_healthy
     volumes:
       - ./frontend:/app
       - /app/node_modules


### PR DESCRIPTION
Server Component から /auth/me を叩くようになったため、backend がまだ :4000 を listen していない状態で描画すると ECONNREFUSED で 500 になる。 depends_on に condition が無く「コンテナが起動した」までしか待っていなかった。

backend に healthcheck を足して service_healthy を待たせる。
entrypoint の migration 適用と air の初回ビルドで時間がかかるので、
その間の失敗を数えないよう start_period を長めに取ってある。

<!-- I want to review in Japanese. -->
## 内容
xxxの改修をしました。

#### 動作確認項目
- [x] localエラーは出てないか？
- [x] 不要なバイナリファイルは存在していないか？
- [x] xxxxxx

####　タスクページ


<!--
レビュー観点（Go / Clean Architecture）
- domain が外側（net/http、DB ドライバ、usecase）を import していないか
- usecase が具象型ではなく interface に依存しているか
- GORM のタグが domain に漏れていないか（永続化モデルは infrastructure/model.go）
- error を握りつぶしていないか（`_ = doSomething()` になっていないか）
- goroutine のリーク・競合状態がないか
-->

<!-- for GitHub Copilot review rule -->
<!--
レビューする際には、以下のprefix(接頭辞)をつけてください
[must]  
[imo] (in my opinion)  
[nits](nitpick) 
[ask]  
[fyi]
-->
<!-- for GitHub Copilot review rule -->

<!-- I want to review in Japanese. -->